### PR TITLE
Upgrade dev dependencies and drop PHP 8.2 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.3, 8.4]
+        php: [8.3, 8.4]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }}
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+## Project
+
+Kirby SEO – Minimal SEO plugin for Kirby CMS generating meta, Open Graph and Twitter Card tags.
+
+## Commands
+
+```bash
+composer install          # Install dependencies
+composer test             # Run all checks (rector, pint, phpstan, pest)
+composer test:unit        # Pest unit tests only
+composer test:types       # PHPStan analysis
+composer lint             # Fix code style (Pint, PSR-12)
+composer refacto          # Run Rector refactoring
+composer coverage         # Tests with coverage report
+```
+
+## Structure
+
+- `src/` – Plugin core (`KirbySeo` class, interface, bootstrap)
+- `snippets/meta.php` – HTML meta tags rendering
+- `blueprints/fields/` – Kirby Panel field definitions (seo.yml, site.yml)
+- `translations/` – i18n (en, fr)
+- `tests/` – Pest tests
+
+## Conventions
+
+- PHP 8.2+ runtime, PHP 8.3+ for dev tools
+- Strict types in all PHP files
+- PSR-12 code style (Laravel Pint)
+- PHPStan level 6
+- All Kirby field names prefixed with `kirbyseo`
+- Tests create isolated Kirby `App` instances, cleaned up in `afterEach`

--- a/composer.json
+++ b/composer.json
@@ -79,8 +79,8 @@
     },
     "require-dev": {
         "laravel/pint": "^1.17",
-        "pestphp/pest": "^3.0",
-        "phpstan/phpstan": "^1.12",
-        "rector/rector": "^1.0"
+        "pestphp/pest": "^4.0",
+        "phpstan/phpstan": "^2.0",
+        "rector/rector": "^2.0"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,9 +5,6 @@ parameters:
     - tests/
 
   level: 6
-  #  excludePaths:
-  #    - site/config/routes.php
+
   ignoreErrors:
     - "#Call to an undefined method Kirby#"
-#
-#    checkMissingIterableValueType: false

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="Test Suite">
       <directory suffix="Test.php">./tests</directory>
     </testsuite>
   </testsuites>
-  <coverage/>
   <source>
     <include>
       <directory suffix=".php">./src</directory>

--- a/rector.php
+++ b/rector.php
@@ -3,26 +3,20 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->paths([
+return RectorConfig::configure()
+    ->withPaths([
         __DIR__ . '/snippets',
         __DIR__ . '/src',
         __DIR__ . '/tests',
-    ]);
-
-    $rectorConfig->autoloadPaths([
-        './src/bootstrap.php'
-    ]);
-
-    $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_82,
-        SetList::PHP_82,
-        SetList::CODE_QUALITY,
-        SetList::DEAD_CODE,
-        SetList::PRIVATIZATION,
-        SetList::TYPE_DECLARATION,
-    ]);
-};
+    ])
+    ->withAutoloadPaths([
+        './src/bootstrap.php',
+    ])
+    ->withPhpSets(php82: true)
+    ->withPreparedSets(
+        codeQuality: true,
+        deadCode: true,
+        privatization: true,
+        typeDeclarations: true,
+    );


### PR DESCRIPTION
## Summary
This PR upgrades the development tooling to their latest major versions and removes PHP 8.2 from the test matrix, aligning with the project's minimum PHP 8.3+ requirement for development.

## Key Changes

- **Dependency upgrades:**
  - Pest: `^3.0` → `^4.0`
  - PHPStan: `^1.12` → `^2.0`
  - Rector: `^1.0` → `^2.0`

- **CI/CD updates:**
  - Removed PHP 8.2 from GitHub Actions test matrix (now tests PHP 8.3 and 8.4 only)
  - Updated PHPUnit schema from 10.1 to 12.0
  - Removed deprecated `<coverage/>` element from phpunit.xml

- **Configuration refactoring:**
  - Modernized `rector.php` to use fluent API (`RectorConfig::configure()`)
  - Simplified PHPStan config by removing commented-out sections
  - Updated Rector to use `withPhpSets()` and `withPreparedSets()` methods

- **Documentation:**
  - Added `CLAUDE.md` with project overview, commands, structure, and conventions

## Notes
All changes maintain backward compatibility with the plugin's runtime requirements while ensuring dev tools are optimized for PHP 8.3+.

https://claude.ai/code/session_01JoukR3dyLK8kkY9SQ4TS7B